### PR TITLE
Feature/39 system health endpoint

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -84,14 +84,8 @@ jobs:
               console.log('No issue number found in branch name or commits — skipping.');
               return;
             }
-  
-            console.log(`Found issue #${issueNumber} from push on branch "${branchName}"`);
-  
-            const { data: issue } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: parseInt(issueNumber),
-            });
+            
+            console.log(`Issues detected: ${[...allIssues].join(', ')}`);
             
             for (const issueNumber of allIssues) {
               const { data: issue } = await github.rest.issues.get({

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -66,15 +66,21 @@ jobs:
             // ────────────────────────────────────────────────────────────────────────────────
   
             const branchMatch = branchName.match(/(?:^|[\/\-_])(\d+)(?:[\/\-_]|$)/);
-            const commitMatch = commitMessages.match(
-              /(?:closes?|fixes?|resolves?|refs?)\s+#(\d+)|(?:^|\s)#(\d+)/im
-            );
+            const commitMatches = [...commitMessages.matchAll(/(?:closes?|fixes?|resolves?|refs?)\s+#(\d+)|(?:^|\s)#(\d+)/gim)];
+            
+            const commitIssueNumbers = commitMatches.map(m => m[1] || m[2]);
+            
+            const allIssues = new Set();
+            
+            if (branchMatch) {
+              allIssues.add(branchMatch[1]);
+            }
+            
+            commitIssueNumbers.forEach(num => {
+              if (num) allIssues.add(num);
+            });
   
-            const issueNumber = branchMatch?.[1]
-              || commitMatch?.[1]
-              || commitMatch?.[2];
-  
-            if (!issueNumber) {
+            if (allIssues.size === 0) {
               console.log('No issue number found in branch name or commits — skipping.');
               return;
             }
@@ -86,8 +92,17 @@ jobs:
               repo: context.repo.repo,
               issue_number: parseInt(issueNumber),
             });
-  
+            
+            for (const issueNumber of allIssues) {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: parseInt(issueNumber),
+            });
+            
+            console.log(`Moving issue #${issueNumber} to In progress`);
             await move(github, issue.node_id, 'In progress');
+            }
 
   # ─── IN PROGRESS → IN REVIEW ───────────────────────────────────────────────
   move-to-in-review:
@@ -103,38 +118,41 @@ jobs:
           script: |
             const move = require('./.github/scripts/move-project-card.js');
             const getLinkedIssues = require('./.github/scripts/get-linked-issues.js');
-
+            
             const prNumber = context.payload.pull_request.number;
             const prBody   = context.payload.pull_request.body  || '';
             const prTitle  = context.payload.pull_request.title || '';
             const combined = `${prTitle}\n${prBody}`;
 
-            // 1. Try to find the issue by text (closes #42, etc.)
-            const textMatch =
-              combined.match(/(?:closes?|fixes?|resolves?|refs?)\s+#(\d+)/i) ||
-              combined.match(/#(\d+)/);
+            const textMatches = [...combined.matchAll(
+              /(?:closes?|fixes?|resolves?|refs?)\s+#(\d+)|#(\d+)/gim
+            )];
+            
+            const textIssueNumbers = textMatches.map(m => m[1] || m[2]);
 
-            let issueNodeIds = [];
+            const linkedIssueNodeIds = await getLinkedIssues(github, context, prNumber);
 
-            if (textMatch) {
-              console.log(`Issue #${textMatch[1]} found in the PR text`);
+            const issueNodeIds = new Set(linkedIssueNodeIds);
+            
+            for (const issueNumber of textIssueNumbers) {
+              if (!issueNumber) continue;
+          
               const { data: issue } = await github.rest.issues.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: parseInt(textMatch[1]),
+                issue_number: parseInt(issueNumber),
               });
-              issueNodeIds = [issue.node_id];
-            } else {
-              // 2. Fallback: GraphQL query for the Development section link
-              console.log('There is no reference in text, searching for Development link...');
-              issueNodeIds = await getLinkedIssues(github, context, prNumber);
+          
+              issueNodeIds.add(issue.node_id);
             }
 
-            if (issueNodeIds.length === 0) {
+            if (issueNodeIds.size === 0) {
               console.log('No linked issues found — skipping.');
               return;
             }
-
+            
+            console.log(`Moving ${issueNodeIds.size} issue(s) to In review`);
+            
             for (const nodeId of issueNodeIds) {
               await move(github, nodeId, 'In review');
             }
@@ -156,35 +174,45 @@ jobs:
           script: |
             const move = require('./.github/scripts/move-project-card.js');
             const getLinkedIssues = require('./.github/scripts/get-linked-issues.js');
-
+            
             const prNumber = context.payload.pull_request.number;
             const prBody   = context.payload.pull_request.body  || '';
             const prTitle  = context.payload.pull_request.title || '';
-            const combined = `${prTitle}\n${prBody}`;
+            
+            const regex = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gim;
 
-            const textMatch =
-              combined.match(/(?:closes?|fixes?|resolves?|refs?)\s+#(\d+)/i) ||
-              combined.match(/#(\d+)/);
+            const bodyMatches = [...prBody.matchAll(regex)].map(m => m[1]);
 
-            let issueNodeIds = [];
+            const titleMatches = [...prTitle.matchAll(regex)].map(m => m[1]);
 
-            if (textMatch) {
-              console.log(`Issue #${textMatch[1]} found in the PR text`);
+            const linkedIssueNodeIds = await getLinkedIssues(github, context, prNumber);
+
+            const issueNodeIds = new Set();
+
+            const allTextIssues = [...bodyMatches, ...titleMatches];
+            
+            for (const issueNumber of allTextIssues) {
+              if (!issueNumber) continue;
+            
               const { data: issue } = await github.rest.issues.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: parseInt(textMatch[1]),
+                issue_number: parseInt(issueNumber),
               });
-              issueNodeIds = [issue.node_id];
-            } else {
-              console.log('There is no reference in text, searching for Development link...');
-              issueNodeIds = await getLinkedIssues(github, context, prNumber);
+            
+              issueNodeIds.add(issue.node_id);
             }
-
-            if (issueNodeIds.length === 0) {
+            
+            for (const nodeId of linkedIssueNodeIds) {
+              issueNodeIds.add(nodeId);
+            }
+            
+            if (issueNodeIds.size === 0) {
               console.log('No linked issues found — skipping.');
               return;
             }
+            
+            console.log(`Moving ${issueNodeIds.size} unique issue(s) to Done`);
 
             for (const nodeId of issueNodeIds) {
               await move(github, nodeId, 'Done');

--- a/docs/ms-gateway.md
+++ b/docs/ms-gateway.md
@@ -66,7 +66,8 @@ Requests to routes **not included** in the protected configuration will be forwa
 ```json
 {
   "gateway": "UP",
-  "timestamp": "2025-01-15T10:30:00Z",
+  "timestamp": "2025-01-15T10:30:000Z",
+  "dependencies": "UP",
   "services": {
     "ms-auth": "UP",
     "ms-leagues": "UP",

--- a/ms-dashboard/pom.xml
+++ b/ms-dashboard/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sportspulse</groupId>
 	<artifactId>dashboard</artifactId>
-	<version>0.0.2</version>
+	<version>0.1.0</version>
 	<name/>
 	<description/>
 	<url/>
@@ -64,6 +64,10 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ms-dashboard/src/main/resources/application.properties
+++ b/ms-dashboard/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}
 spring.config.import=optional:file:.env[.properties]
 logging.level.org.springframework=${SPORTS_PULSE_LEVEL_LOGIN:WARN}
 logging.level.root=${SPORTS_PULSE_LEVEL_LOGIN:INFO}
+management.endpoints.web.exposure.include=health
 
 # Documentation Configuration (Swagger/OpenAPI)
 springdoc.api-docs.enabled=${SWAGGER_UI_DOCUMENTATION_ENABLED:false}

--- a/ms-fixtures/pom.xml
+++ b/ms-fixtures/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sportspulse</groupId>
 	<artifactId>fixtures</artifactId>
-	<version>0.0.2</version>
+	<version>0.1.0</version>
 	<name/>
 	<description/>
 	<url/>
@@ -64,6 +64,10 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ms-fixtures/src/main/resources/application.properties
+++ b/ms-fixtures/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}
 spring.config.import=optional:file:.env[.properties]
 logging.level.org.springframework=${SPORTS_PULSE_LEVEL_LOGIN:WARN}
 logging.level.root=${SPORTS_PULSE_LEVEL_LOGIN:INFO}
+management.endpoints.web.exposure.include=health
 
 # Documentation Configuration (Swagger/OpenAPI)
 springdoc.api-docs.enabled=${SWAGGER_UI_DOCUMENTATION_ENABLED:false}

--- a/ms-gateway/pom.xml
+++ b/ms-gateway/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sportspulse</groupId>
 	<artifactId>gateway</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0</version>
 	<name/>
 	<description/>
 	<url/>

--- a/ms-gateway/pom.xml
+++ b/ms-gateway/pom.xml
@@ -81,6 +81,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/config/WebClientConfig.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/config/WebClientConfig.java
@@ -1,0 +1,18 @@
+package com.sportspulse.gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * WebClientConfig Provides configuration for creating a {@link WebClient} bean. Enables reactive
+ * HTTP requests throughout the application.
+ */
+@Configuration
+public class WebClientConfig {
+
+  @Bean
+  public WebClient webClient(WebClient.Builder builder) {
+    return builder.build();
+  }
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/config/constants/ApiPaths.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/config/constants/ApiPaths.java
@@ -1,0 +1,13 @@
+package com.sportspulse.gateway.config.constants;
+
+/**
+ * ApiPaths Defines common API endpoint paths used across the application. Provides centralized
+ * constants to avoid duplication and ensure consistency.
+ */
+public final class ApiPaths {
+
+  private ApiPaths() {}
+
+  /** Path for the health check endpoint. */
+  public static final String HEALTH = "/health";
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/config/constants/ApiPathsServices.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/config/constants/ApiPathsServices.java
@@ -12,4 +12,12 @@ public final class ApiPathsServices {
     public static final String LOGIN = String.join("", BASE, "/login");
     public static final String VALIDATE_TOKEN = String.join("", BASE, "/validate");
   }
+
+  /**
+   * Health Defines constants related to health check endpoints. Provides the actuator health path
+   * for monitoring service availability.
+   */
+  public static final class Health {
+    public static final String ACTUATOR_HEALTH = "/actuator/health";
+  }
 }

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/controller/HealthController.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/controller/HealthController.java
@@ -1,0 +1,28 @@
+package com.sportspulse.gateway.controller;
+
+import com.sportspulse.gateway.config.constants.ApiPaths;
+import com.sportspulse.gateway.dto.responses.HealthResponse;
+import com.sportspulse.gateway.services.HealthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * HealthController REST controller that exposes the health check endpoint. Delegates to {@link
+ * HealthService} to retrieve the aggregated health status of the gateway and its dependent
+ * services.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(ApiPaths.HEALTH)
+public class HealthController {
+
+  private final HealthService healthService;
+
+  @GetMapping
+  public Mono<HealthResponse> getHealthServices() {
+    return healthService.getHeathStatusServices();
+  }
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/dto/responses/HealthResponse.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/dto/responses/HealthResponse.java
@@ -15,6 +15,7 @@ import lombok.Value;
 @Builder
 public class HealthResponse {
   ServiceStatus gateway;
+  ServiceStatus dependencies;
 
   @Builder.Default Instant timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
 

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/dto/responses/HealthResponse.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/dto/responses/HealthResponse.java
@@ -1,0 +1,22 @@
+package com.sportspulse.gateway.dto.responses;
+
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * HealthResponse Represents the health status of the gateway and its dependent services. Contains
+ * the gateway status, a timestamp of the health check, and a map of individual service statuses.
+ */
+@Value
+@Builder
+public class HealthResponse {
+  ServiceStatus gateway;
+
+  @Builder.Default Instant timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+  Map<String, String> services;
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/dto/responses/HealthResponse.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/dto/responses/HealthResponse.java
@@ -18,5 +18,5 @@ public class HealthResponse {
 
   @Builder.Default Instant timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS);
 
-  Map<String, String> services;
+  Map<String, ServiceStatus> services;
 }

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClient.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClient.java
@@ -1,6 +1,6 @@
 package com.sportspulse.gateway.integration.client;
 
-import com.sportspulse.gateway.integration.dtos.responses.ServiceResponse;
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
 
 /**
  * ServiceClient Defines the contract for interacting with external services. Provides a method to
@@ -12,7 +12,8 @@ public interface ServiceClient {
    * Retrieves the health status of a service from the given base URL.
    *
    * @param baseUrl the base URL of the service
+   * @param serviceName the name of the service for logging and identification purposes
    * @return a ServiceResponse containing the service status
    */
-  ServiceResponse getHealthService(String baseUrl);
+  ServiceStatus getHealthService(String serviceName, String baseUrl);
 }

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClient.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClient.java
@@ -1,0 +1,18 @@
+package com.sportspulse.gateway.integration.client;
+
+import com.sportspulse.gateway.integration.dtos.responses.ServiceResponse;
+
+/**
+ * ServiceClient Defines the contract for interacting with external services. Provides a method to
+ * retrieve the health status of a service.
+ */
+public interface ServiceClient {
+
+  /**
+   * Retrieves the health status of a service from the given base URL.
+   *
+   * @param baseUrl the base URL of the service
+   * @return a ServiceResponse containing the service status
+   */
+  ServiceResponse getHealthService(String baseUrl);
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClient.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClient.java
@@ -1,6 +1,7 @@
 package com.sportspulse.gateway.integration.client;
 
 import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import reactor.core.publisher.Mono;
 
 /**
  * ServiceClient Defines the contract for interacting with external services. Provides a method to
@@ -15,5 +16,5 @@ public interface ServiceClient {
    * @param serviceName the name of the service for logging and identification purposes
    * @return a ServiceResponse containing the service status
    */
-  ServiceStatus getHealthService(String serviceName, String baseUrl);
+  Mono<ServiceStatus> getHealthService(String serviceName, String baseUrl);
 }

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClientImpl.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClientImpl.java
@@ -23,7 +23,7 @@ public class ServiceClientImpl implements ServiceClient {
   private final WebClient webClient;
 
   @Override
-  public ServiceStatus getHealthService(String serviceName, String baseUrl) {
+  public Mono<ServiceStatus> getHealthService(String serviceName, String baseUrl) {
 
     return webClient
         .get()
@@ -42,8 +42,7 @@ public class ServiceClientImpl implements ServiceClient {
                     e.getMessage());
               }
               return Mono.just(ServiceStatus.DOWN);
-            })
-        .block();
+            });
   }
 
   private ServiceStatus mapToStatus(String serviceName, String baseUrl, ServiceResponse response) {

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClientImpl.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/integration/client/ServiceClientImpl.java
@@ -1,0 +1,71 @@
+package com.sportspulse.gateway.integration.client;
+
+import com.sportspulse.gateway.config.constants.ApiPathsServices;
+import com.sportspulse.gateway.integration.dtos.responses.ServiceResponse;
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * ServiceClientImpl Implementation of {@link ServiceClient} that uses {@link WebClient} to check
+ * the health status of external services via their actuator endpoints. Provides error handling and
+ * logging to mark services as DOWN when requests fail, time out, or return invalid responses.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ServiceClientImpl implements ServiceClient {
+
+  private final WebClient webClient;
+
+  @Override
+  public ServiceStatus getHealthService(String serviceName, String baseUrl) {
+
+    return webClient
+        .get()
+        .uri(baseUrl + ApiPathsServices.Health.ACTUATOR_HEALTH)
+        .retrieve()
+        .bodyToMono(ServiceResponse.class)
+        .map(response -> mapToStatus(serviceName, baseUrl, response))
+        .timeout(Duration.ofSeconds(2))
+        .onErrorResume(
+            e -> {
+              if (log.isErrorEnabled()) {
+                log.error(
+                    "Service [{}] DOWN - URL: {} - Error: {}",
+                    serviceName,
+                    baseUrl,
+                    e.getMessage());
+              }
+              return Mono.just(ServiceStatus.DOWN);
+            })
+        .block();
+  }
+
+  private ServiceStatus mapToStatus(String serviceName, String baseUrl, ServiceResponse response) {
+
+    if (response == null || response.getStatus() == null) {
+      if (log.isErrorEnabled()) {
+        log.error("Service [{}] DOWN - URL: {} - Reason: empty or null body", serviceName, baseUrl);
+      }
+      return ServiceStatus.DOWN;
+    }
+
+    if (!"UP".equalsIgnoreCase(response.getStatus().name())) {
+      if (log.isErrorEnabled()) {
+        log.error(
+            "Service [{}] DOWN - URL: {} - Actuator status: {}",
+            serviceName,
+            baseUrl,
+            response.getStatus());
+      }
+      return ServiceStatus.DOWN;
+    }
+
+    return ServiceStatus.UP;
+  }
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/integration/dtos/responses/ServiceResponse.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/integration/dtos/responses/ServiceResponse.java
@@ -1,11 +1,17 @@
 package com.sportspulse.gateway.integration.dtos.responses;
 
 import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
 
 /**
  * ServiceResponse Represents the response status of a service. Encapsulates the current {@link
  * ServiceStatus} for monitoring or reporting purposes.
- *
- * @param status the status of the service
  */
-public record ServiceResponse(ServiceStatus status) {}
+@Value
+@Getter
+@Builder
+public class ServiceResponse {
+  ServiceStatus status;
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/integration/dtos/responses/ServiceResponse.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/integration/dtos/responses/ServiceResponse.java
@@ -1,0 +1,11 @@
+package com.sportspulse.gateway.integration.dtos.responses;
+
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+
+/**
+ * ServiceResponse Represents the response status of a service. Encapsulates the current {@link
+ * ServiceStatus} for monitoring or reporting purposes.
+ *
+ * @param status the status of the service
+ */
+public record ServiceResponse(ServiceStatus status) {}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthService.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthService.java
@@ -1,17 +1,18 @@
 package com.sportspulse.gateway.services;
 
 import com.sportspulse.gateway.dto.responses.HealthResponse;
+import reactor.core.publisher.Mono;
 
 /**
  * ServiceHealth Defines the contract for retrieving the overall health status of the gateway and
  * its dependent services.
  */
-public interface ServiceHealth {
+public interface HealthService {
 
   /**
    * Retrieves the aggregated health status of all monitored services.
    *
    * @return a HealthResponse containing gateway and service statuses
    */
-  HealthResponse getHeathStatusServices();
+  Mono<HealthResponse> getHeathStatusServices();
 }

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthServiceImpl.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthServiceImpl.java
@@ -5,25 +5,26 @@ import com.sportspulse.gateway.dto.responses.HealthResponse;
 import com.sportspulse.gateway.integration.client.ServiceClient;
 import com.sportspulse.gateway.utils.enums.ServiceStatus;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
- * ServiceHealthImpl Implementation of {@link ServiceHealth} that aggregates the health status of
+ * ServiceHealthImpl Implementation of {@link HealthService} that aggregates the health status of
  * the gateway and its dependent microservices. Uses {@link ServiceClient} to query each service's
  * actuator health endpoint and determines the overall gateway status based on the availability of
  * all services.
  */
 @Service
 @RequiredArgsConstructor
-public class ServiceHealthImpl implements ServiceHealth {
+public class HealthServiceImpl implements HealthService {
 
   private final ServiceClient serviceClient;
   private final GatewayServicesProperties properties;
 
   @Override
-  public HealthResponse getHeathStatusServices() {
+  public Mono<HealthResponse> getHeathStatusServices() {
     Map<String, String> servicesConfig =
         Map.of(
             "ms-auth", properties.getAuth(),
@@ -34,18 +35,24 @@ public class ServiceHealthImpl implements ServiceHealth {
             "ms-notifications", properties.getNotifications(),
             "ms-dashboard", properties.getDashboard());
 
-    Map<String, ServiceStatus> servicesStatus =
-        servicesConfig.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> serviceClient.getHealthService(entry.getKey(), entry.getValue())));
+    return Flux.fromIterable(servicesConfig.entrySet())
+        .flatMap(
+            entry ->
+                serviceClient
+                    .getHealthService(entry.getKey(), entry.getValue())
+                    .map(status -> Map.entry(entry.getKey(), status)))
+        .collectMap(Map.Entry::getKey, Map.Entry::getValue)
+        .map(
+            servicesStatus -> {
+              ServiceStatus gatewayStatus =
+                  servicesStatus.values().stream().allMatch(status -> status == ServiceStatus.UP)
+                      ? ServiceStatus.UP
+                      : ServiceStatus.DOWN;
 
-    ServiceStatus gatewayStatus =
-        servicesStatus.values().stream().allMatch(status -> status == ServiceStatus.UP)
-            ? ServiceStatus.UP
-            : ServiceStatus.DOWN;
-
-    return HealthResponse.builder().gateway(gatewayStatus).services(servicesStatus).build();
+              return HealthResponse.builder()
+                  .gateway(gatewayStatus)
+                  .services(servicesStatus)
+                  .build();
+            });
   }
 }

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthServiceImpl.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthServiceImpl.java
@@ -47,7 +47,8 @@ public class HealthServiceImpl implements HealthService {
         .flatMap(
             servicesStatus -> {
               ServiceStatus dependenciesStatus =
-                  servicesStatus.values().stream().allMatch(s -> s == ServiceStatus.UP)
+                  !servicesStatus.isEmpty()
+                          && servicesStatus.values().stream().allMatch(s -> s == ServiceStatus.UP)
                       ? ServiceStatus.UP
                       : ServiceStatus.DOWN;
 

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthServiceImpl.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/services/HealthServiceImpl.java
@@ -3,6 +3,7 @@ package com.sportspulse.gateway.services;
 import com.sportspulse.gateway.config.properties.GatewayServicesProperties;
 import com.sportspulse.gateway.dto.responses.HealthResponse;
 import com.sportspulse.gateway.integration.client.ServiceClient;
+import com.sportspulse.gateway.services.components.GatewayHealthIndicator;
 import com.sportspulse.gateway.utils.enums.ServiceStatus;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class HealthServiceImpl implements HealthService {
 
   private final ServiceClient serviceClient;
   private final GatewayServicesProperties properties;
+  private final GatewayHealthIndicator gatewayHealthIndicator;
 
   @Override
   public Mono<HealthResponse> getHeathStatusServices() {
@@ -42,17 +44,22 @@ public class HealthServiceImpl implements HealthService {
                     .getHealthService(entry.getKey(), entry.getValue())
                     .map(status -> Map.entry(entry.getKey(), status)))
         .collectMap(Map.Entry::getKey, Map.Entry::getValue)
-        .map(
+        .flatMap(
             servicesStatus -> {
-              ServiceStatus gatewayStatus =
-                  servicesStatus.values().stream().allMatch(status -> status == ServiceStatus.UP)
+              ServiceStatus dependenciesStatus =
+                  servicesStatus.values().stream().allMatch(s -> s == ServiceStatus.UP)
                       ? ServiceStatus.UP
                       : ServiceStatus.DOWN;
 
-              return HealthResponse.builder()
-                  .gateway(gatewayStatus)
-                  .services(servicesStatus)
-                  .build();
+              return gatewayHealthIndicator
+                  .getGatewayStatus()
+                  .map(
+                      gatewayStatus ->
+                          HealthResponse.builder()
+                              .gateway(gatewayStatus)
+                              .dependencies(dependenciesStatus)
+                              .services(servicesStatus)
+                              .build());
             });
   }
 }

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/services/ServiceHealth.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/services/ServiceHealth.java
@@ -1,0 +1,17 @@
+package com.sportspulse.gateway.services;
+
+import com.sportspulse.gateway.dto.responses.HealthResponse;
+
+/**
+ * ServiceHealth Defines the contract for retrieving the overall health status of the gateway and
+ * its dependent services.
+ */
+public interface ServiceHealth {
+
+  /**
+   * Retrieves the aggregated health status of all monitored services.
+   *
+   * @return a HealthResponse containing gateway and service statuses
+   */
+  HealthResponse getHeathStatusServices();
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/services/ServiceHealthImpl.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/services/ServiceHealthImpl.java
@@ -1,0 +1,51 @@
+package com.sportspulse.gateway.services;
+
+import com.sportspulse.gateway.config.properties.GatewayServicesProperties;
+import com.sportspulse.gateway.dto.responses.HealthResponse;
+import com.sportspulse.gateway.integration.client.ServiceClient;
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * ServiceHealthImpl Implementation of {@link ServiceHealth} that aggregates the health status of
+ * the gateway and its dependent microservices. Uses {@link ServiceClient} to query each service's
+ * actuator health endpoint and determines the overall gateway status based on the availability of
+ * all services.
+ */
+@Service
+@RequiredArgsConstructor
+public class ServiceHealthImpl implements ServiceHealth {
+
+  private final ServiceClient serviceClient;
+  private final GatewayServicesProperties properties;
+
+  @Override
+  public HealthResponse getHeathStatusServices() {
+    Map<String, String> servicesConfig =
+        Map.of(
+            "ms-auth", properties.getAuth(),
+            "ms-leagues", properties.getLeagues(),
+            "ms-teams", properties.getTeams(),
+            "ms-fixtures", properties.getFixtures(),
+            "ms-standings", properties.getStandings(),
+            "ms-notifications", properties.getNotifications(),
+            "ms-dashboard", properties.getDashboard());
+
+    Map<String, ServiceStatus> servicesStatus =
+        servicesConfig.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> serviceClient.getHealthService(entry.getKey(), entry.getValue())));
+
+    ServiceStatus gatewayStatus =
+        servicesStatus.values().stream().allMatch(status -> status == ServiceStatus.UP)
+            ? ServiceStatus.UP
+            : ServiceStatus.DOWN;
+
+    return HealthResponse.builder().gateway(gatewayStatus).services(servicesStatus).build();
+  }
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/services/components/GatewayHealthIndicator.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/services/components/GatewayHealthIndicator.java
@@ -1,0 +1,39 @@
+package com.sportspulse.gateway.services.components;
+
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+/**
+ * GatewayHealthIndicator Reactive health indicator for the gateway application. Implements {@link
+ * ReactiveHealthIndicator} to expose the gateway health status and provides a method to map it into
+ * a {@link ServiceStatus}.
+ */
+@Component
+@RequiredArgsConstructor
+public class GatewayHealthIndicator implements ReactiveHealthIndicator {
+
+  @Override
+  public Mono<Health> health() {
+    return Mono.just(Health.up().build());
+  }
+
+  /**
+   * Retrieves the gateway status as a {@link ServiceStatus}. Maps the actuator health status to UP
+   * or DOWN and falls back to DOWN on errors.
+   *
+   * @return a Mono emitting the gateway {@link ServiceStatus}
+   */
+  public Mono<ServiceStatus> getGatewayStatus() {
+    return health()
+        .map(
+            h ->
+                "UP".equalsIgnoreCase(h.getStatus().getCode())
+                    ? ServiceStatus.UP
+                    : ServiceStatus.DOWN)
+        .onErrorReturn(ServiceStatus.DOWN);
+  }
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/utils/enums/ServiceStatus.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/utils/enums/ServiceStatus.java
@@ -1,0 +1,6 @@
+package com.sportspulse.gateway.utils.enums;
+
+public enum ServiceStatus {
+    UP,
+    DOWN
+}

--- a/ms-gateway/src/main/java/com/sportspulse/gateway/utils/enums/ServiceStatus.java
+++ b/ms-gateway/src/main/java/com/sportspulse/gateway/utils/enums/ServiceStatus.java
@@ -1,6 +1,10 @@
 package com.sportspulse.gateway.utils.enums;
 
+/**
+ * ServiceStatus Represents the operational state of a service. Indicates whether the service is
+ * currently available (UP) or unavailable (DOWN).
+ */
 public enum ServiceStatus {
-    UP,
-    DOWN
+  UP,
+  DOWN
 }

--- a/ms-gateway/src/main/resources/application.properties
+++ b/ms-gateway/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}
 spring.config.import=optional:file:.env[.properties]
 logging.level.org.springframework=${SPORTS_PULSE_LEVEL_LOGIN:WARN}
 logging.level.root=${SPORTS_PULSE_LEVEL_LOGIN:INFO}
+management.endpoints.web.exposure.include=health
 
 # Redis Configuration
 spring.data.redis.host=${SPORTS_PULSE_REDIS_HOST}

--- a/ms-gateway/src/test/java/com/sportspulse/gateway/AbstractIntegrationTest.java
+++ b/ms-gateway/src/test/java/com/sportspulse/gateway/AbstractIntegrationTest.java
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.redis.testcontainers.RedisContainer;
-import org.junit.jupiter.api.AfterAll;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -21,7 +20,7 @@ public class AbstractIntegrationTest {
 
   static final boolean IS_CI = System.getenv("CI") != null;
 
-  static RedisContainer REDIS;
+  static final RedisContainer REDIS;
 
   protected static final WireMockServer wireMock;
 
@@ -35,14 +34,9 @@ public class AbstractIntegrationTest {
       REDIS =
           new RedisContainer(DockerImageName.parse("redis:8.6.2-alpine"))
               .waitingFor(Wait.forListeningPort());
-      REDIS.start();
-    }
-  }
-
-  @AfterAll
-  static void stopContainers() {
-    if (REDIS != null && REDIS.isRunning()) {
-      REDIS.stop();
+      REDIS.start(); // ← start() explícito aquí, ANTES de @DynamicPropertySource
+    } else {
+      REDIS = null;
     }
   }
 
@@ -56,5 +50,16 @@ public class AbstractIntegrationTest {
       registry.add("spring.data.redis.port", () -> 6379);
     }
     registry.add("sportspulse.gateway.services.auth", () -> "http://localhost:" + wireMock.port());
+    registry.add(
+        "sportspulse.gateway.services.leagues", () -> "http://localhost:" + wireMock.port());
+    registry.add("sportspulse.gateway.services.teams", () -> "http://localhost:" + wireMock.port());
+    registry.add(
+        "sportspulse.gateway.services.fixtures", () -> "http://localhost:" + wireMock.port());
+    registry.add(
+        "sportspulse.gateway.services.standings", () -> "http://localhost:" + wireMock.port());
+    registry.add(
+        "sportspulse.gateway.services.notifications", () -> "http://localhost:" + wireMock.port());
+    registry.add(
+        "sportspulse.gateway.services.dashboard", () -> "http://localhost:" + wireMock.port());
   }
 }

--- a/ms-gateway/src/test/java/com/sportspulse/gateway/controller/HealthControllerIntegrationTest.java
+++ b/ms-gateway/src/test/java/com/sportspulse/gateway/controller/HealthControllerIntegrationTest.java
@@ -1,10 +1,349 @@
 package com.sportspulse.gateway.controller;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.sportspulse.gateway.AbstractIntegrationTest;
+import com.sportspulse.gateway.config.constants.ApiPaths;
+import com.sportspulse.gateway.config.constants.ApiPathsServices;
+import com.sportspulse.gateway.dto.responses.HealthResponse;
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+@DisplayName("GET /health - Integration Tests")
 class HealthControllerIntegrationTest extends AbstractIntegrationTest {
 
+  // Actuator response when the service is UP
+  private static final String BODY_UP =
+      """
+      {"status":"UP"}
+      """;
+
+  // Actuator response when the service is DOWN
+  private static final String BODY_DOWN =
+      """
+      {"status":"DOWN"}
+      """;
+
   @Autowired private WebTestClient webTestClient;
+
+  @AfterEach
+  void resetWireMock() {
+    wireMock.resetAll();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers to register stubs in WireMock
+  // -------------------------------------------------------------------------
+
+  /** Stub that responds 200 with status UP for the /actuator/health path. */
+  private void stubServiceUp() {
+    wireMock.stubFor(
+        get(urlEqualTo(ApiPathsServices.Health.ACTUATOR_HEALTH))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(BODY_UP)));
+  }
+
+  /** Stub that responds 200 with status DOWN for the /actuator/health path. */
+  private void stubServiceDown() {
+    wireMock.stubFor(
+        get(urlEqualTo(ApiPathsServices.Health.ACTUATOR_HEALTH))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(BODY_DOWN)));
+  }
+
+  /**
+   * Stub that forces a timeout (delay greater than the one configured in WebClient, which is 2 s).
+   * The value used is 3 000 ms to exceed the 2 s timeout defined in ServiceClientImpl.
+   */
+  private void stubServiceTimeout() {
+    wireMock.stubFor(
+        get(urlEqualTo(ApiPathsServices.Health.ACTUATOR_HEALTH))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(BODY_UP)
+                    .withFixedDelay(3_000)));
+  }
+
+  /** Stub that responds 200 with an empty body. */
+  private void stubServiceEmptyBody() {
+    wireMock.stubFor(
+        get(urlEqualTo(ApiPathsServices.Health.ACTUATOR_HEALTH))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("")));
+  }
+
+  /** Stub that responds 500 (server error). */
+  private void stubServiceServerError() {
+    wireMock.stubFor(
+        get(urlEqualTo(ApiPathsServices.Health.ACTUATOR_HEALTH))
+            .willReturn(aResponse().withStatus(500)));
+  }
+
+  // -------------------------------------------------------------------------
+  // Test scenarios
+  // -------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("Scenario 1: all services UP")
+  class AllServicesUp {
+
+    @Test
+    @DisplayName("Should return gateway=UP, dependencies=UP and all 7 services UP")
+    void shouldReturnAllUp() {
+      stubServiceUp();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(
+              response -> {
+                assertThat(response.getGateway()).isEqualTo(ServiceStatus.UP);
+                assertThat(response.getDependencies()).isEqualTo(ServiceStatus.UP);
+                assertThat(response.getServices()).hasSize(7);
+                assertThat(response.getServices())
+                    .allSatisfy(
+                        (name, status) ->
+                            assertThat(status)
+                                .as("Service '%s' should be UP", name)
+                                .isEqualTo(ServiceStatus.UP));
+                assertThat(response.getTimestamp()).isNotNull();
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Scenario 2: a single service responds DOWN")
+  class OneDependencyDown {
+
+    /**
+     * WireMock responds DOWN for /actuator/health for ALL services because they all point to the
+     * same mock port. To test a single service DOWN in isolation, an additional WireMockServer on a
+     * different port would be needed.
+     *
+     * <p>This test validates the business rule: if at least one service is DOWN, dependencies must
+     * be DOWN — even though all 7 end up DOWN in this setup.
+     *
+     * <p>For a more surgical test, a second WireMockServer on a dedicated port assigned only to the
+     * target service is recommended.
+     */
+    @Test
+    @DisplayName("Should return dependencies=DOWN when at least one service is DOWN")
+    void shouldReturnDependenciesDownWhenOneServiceIsDown() {
+      // All microservices share the same WireMock by configuration,
+      // so stubbing DOWN affects all 7.
+      stubServiceDown();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(
+              response -> {
+                assertThat(response.getGateway()).isEqualTo(ServiceStatus.UP);
+                assertThat(response.getDependencies()).isEqualTo(ServiceStatus.DOWN);
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Scenario 3: all services respond DOWN")
+  class AllServicesDown {
+
+    @Test
+    @DisplayName("Should return gateway=UP, dependencies=DOWN and all 7 services DOWN")
+    void shouldReturnAllDependenciesDown() {
+      stubServiceDown();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(
+              response -> {
+                assertThat(response.getGateway()).isEqualTo(ServiceStatus.UP);
+                assertThat(response.getDependencies()).isEqualTo(ServiceStatus.DOWN);
+                assertThat(response.getServices()).hasSize(7);
+                assertThat(response.getServices())
+                    .allSatisfy(
+                        (name, status) ->
+                            assertThat(status)
+                                .as("Service '%s' should be DOWN", name)
+                                .isEqualTo(ServiceStatus.DOWN));
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Scenario 4: services do not respond (timeout)")
+  class ServicesTimeout {
+
+    @Test
+    @DisplayName("Should return dependencies=DOWN when services take longer than 2 s")
+    void shouldReturnDownOnTimeout() {
+      stubServiceTimeout();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          // WebClient timeout is 2 s; we add margin so the response can arrive
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(
+              response -> {
+                assertThat(response.getGateway()).isEqualTo(ServiceStatus.UP);
+                assertThat(response.getDependencies()).isEqualTo(ServiceStatus.DOWN);
+                assertThat(response.getServices())
+                    .allSatisfy(
+                        (name, status) ->
+                            assertThat(status)
+                                .as("Service '%s' should be DOWN after timeout", name)
+                                .isEqualTo(ServiceStatus.DOWN));
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Scenario 5: services respond with an empty body")
+  class ServicesEmptyBody {
+
+    @Test
+    @DisplayName("Should return dependencies=DOWN when the response body is empty")
+    void shouldReturnDownOnEmptyBody() {
+      stubServiceEmptyBody();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(
+              response -> {
+                assertThat(response.getGateway()).isEqualTo(ServiceStatus.UP);
+                assertThat(response.getDependencies()).isEqualTo(ServiceStatus.DOWN);
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Scenario 6: services respond with 500")
+  class ServicesServerError {
+
+    @Test
+    @DisplayName("Should return dependencies=DOWN when services respond with 5xx")
+    void shouldReturnDownOnServerError() {
+      stubServiceServerError();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(
+              response -> {
+                assertThat(response.getGateway()).isEqualTo(ServiceStatus.UP);
+                assertThat(response.getDependencies()).isEqualTo(ServiceStatus.DOWN);
+                assertThat(response.getServices())
+                    .allSatisfy(
+                        (name, status) ->
+                            assertThat(status)
+                                .as("Service '%s' should be DOWN after 500", name)
+                                .isEqualTo(ServiceStatus.DOWN));
+              });
+    }
+  }
+
+  @Nested
+  @DisplayName("Scenario 7: response structure validation")
+  class ResponseStructure {
+
+    @Test
+    @DisplayName("Should contain exactly the 7 expected microservices in the services map")
+    void shouldContainExactlySevenServices() {
+      stubServiceUp();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(
+              response ->
+                  assertThat(response.getServices())
+                      .containsOnlyKeys(
+                          "ms-auth",
+                          "ms-leagues",
+                          "ms-teams",
+                          "ms-fixtures",
+                          "ms-standings",
+                          "ms-notifications",
+                          "ms-dashboard"));
+    }
+
+    @Test
+    @DisplayName("Should include a timestamp in the response")
+    void shouldIncludeTimestamp() {
+      stubServiceUp();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(HealthResponse.class)
+          .value(response -> assertThat(response.getTimestamp()).isNotNull());
+    }
+
+    @Test
+    @DisplayName("Should respond with Content-Type application/json")
+    void shouldRespondWithJsonContentType() {
+      stubServiceUp();
+
+      webTestClient
+          .get()
+          .uri(ApiPaths.HEALTH)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectHeader()
+          .contentTypeCompatibleWith(org.springframework.http.MediaType.APPLICATION_JSON);
+    }
+  }
 }

--- a/ms-gateway/src/test/java/com/sportspulse/gateway/controller/HealthControllerIntegrationTest.java
+++ b/ms-gateway/src/test/java/com/sportspulse/gateway/controller/HealthControllerIntegrationTest.java
@@ -1,0 +1,10 @@
+package com.sportspulse.gateway.controller;
+
+import com.sportspulse.gateway.AbstractIntegrationTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+class HealthControllerIntegrationTest extends AbstractIntegrationTest {
+
+  @Autowired private WebTestClient webTestClient;
+}

--- a/ms-gateway/src/test/java/com/sportspulse/gateway/integration/client/ServiceClientImplTest.java
+++ b/ms-gateway/src/test/java/com/sportspulse/gateway/integration/client/ServiceClientImplTest.java
@@ -1,0 +1,190 @@
+package com.sportspulse.gateway.integration.client;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sportspulse.gateway.config.constants.ApiPathsServices;
+import com.sportspulse.gateway.integration.dtos.responses.ServiceResponse;
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ServiceClientImpl Tests")
+class ServiceClientImplTest {
+
+  // -------------------------------------------------------------------------
+  // Mocks — WebClient fluent chain
+  // -------------------------------------------------------------------------
+
+  @Mock private WebClient webClient;
+  @Mock private WebClient.RequestHeadersUriSpec<?> requestHeadersUriSpec;
+  @Mock private WebClient.RequestHeadersSpec<?> requestHeadersSpec;
+  @Mock private WebClient.ResponseSpec responseSpec;
+
+  private ServiceClientImpl serviceClient;
+
+  private static final String SERVICE_NAME = "test-service";
+  private static final String BASE_URL = "http://localhost:8081";
+
+  @BeforeEach
+  void setUp() {
+    serviceClient = new ServiceClientImpl(webClient);
+
+    // doReturn avoids the unchecked-cast issue caused by WebClient's wildcard generics
+    doReturn(requestHeadersUriSpec).when(webClient).get();
+    doReturn(requestHeadersSpec).when(requestHeadersUriSpec).uri(anyString());
+    doReturn(responseSpec).when(requestHeadersSpec).retrieve();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private void givenResponseBody(ServiceResponse response) {
+    when(responseSpec.bodyToMono(ServiceResponse.class)).thenReturn(Mono.just(response));
+  }
+
+  private void givenResponseError(Throwable error) {
+    when(responseSpec.bodyToMono(ServiceResponse.class)).thenReturn(Mono.error(error));
+  }
+
+  private ServiceResponse responseWithStatus(ServiceStatus status) {
+    return ServiceResponse.builder().status(status).build();
+  }
+
+  // =========================================================================
+  // getHealthService()
+  // =========================================================================
+
+  @Nested
+  @DisplayName("getHealthService() - happy path")
+  class HappyPath {
+
+    @Test
+    @DisplayName("should return UP when actuator responds with status UP")
+    void shouldReturnUp_whenActuatorStatusIsUp() {
+      givenResponseBody(responseWithStatus(ServiceStatus.UP));
+
+      StepVerifier.create(serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .expectNext(ServiceStatus.UP)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should call the correct URI (baseUrl + actuator path)")
+    void shouldCallCorrectUri() {
+      givenResponseBody(responseWithStatus(ServiceStatus.UP));
+
+      serviceClient.getHealthService(SERVICE_NAME, BASE_URL).block();
+
+      verify(requestHeadersUriSpec).uri(BASE_URL + ApiPathsServices.Health.ACTUATOR_HEALTH);
+    }
+  }
+
+  // =========================================================================
+  // mapToStatus() — DOWN scenarios
+  // =========================================================================
+
+  @Nested
+  @DisplayName("getHealthService() - mapToStatus DOWN scenarios")
+  class MapToStatusDown {
+
+    @Test
+    @DisplayName("should return DOWN when response body is null")
+    void shouldReturnDown_whenResponseIsNull() {
+      when(responseSpec.bodyToMono(ServiceResponse.class))
+          .thenReturn(Mono.just(ServiceResponse.builder().build()));
+      // ServiceResponse has null status by default
+
+      StepVerifier.create(serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .expectNext(ServiceStatus.DOWN)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should return DOWN when response status field is null")
+    void shouldReturnDown_whenResponseStatusIsNull() {
+      ServiceResponse response = ServiceResponse.builder().build();
+      givenResponseBody(response);
+
+      StepVerifier.create(serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .expectNext(ServiceStatus.DOWN)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should return DOWN when actuator status is DOWN")
+    void shouldReturnDown_whenActuatorStatusIsDown() {
+      givenResponseBody(responseWithStatus(ServiceStatus.DOWN));
+
+      StepVerifier.create(serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .expectNext(ServiceStatus.DOWN)
+          .verifyComplete();
+    }
+  }
+
+  // =========================================================================
+  // onErrorResume — error handling
+  // =========================================================================
+
+  @Nested
+  @DisplayName("getHealthService() - onErrorResume scenarios")
+  class ErrorHandling {
+
+    @Test
+    @DisplayName("should return DOWN when WebClient throws a runtime exception")
+    void shouldReturnDown_whenWebClientThrowsRuntimeException() {
+      givenResponseError(new RuntimeException("Connection refused"));
+
+      StepVerifier.create(serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .expectNext(ServiceStatus.DOWN)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should return DOWN when WebClient throws a WebClientResponseException (e.g. 503)")
+    void shouldReturnDown_whenWebClientResponseExceptionThrown() {
+      givenResponseError(
+          WebClientResponseException.create(503, "Service Unavailable", null, null, null));
+
+      StepVerifier.create(serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .expectNext(ServiceStatus.DOWN)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should return DOWN when request times out")
+    void shouldReturnDown_whenRequestTimesOut() {
+      // Simulate a never-ending response that will be cut by the 2-second timeout
+      when(responseSpec.bodyToMono(ServiceResponse.class)).thenReturn(Mono.never());
+
+      StepVerifier.withVirtualTime(() -> serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .thenAwait(Duration.ofSeconds(3))
+          .expectNext(ServiceStatus.DOWN)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should not propagate errors — Mono must always complete normally")
+    void shouldAlwaysComplete_neverPropagateError() {
+      givenResponseError(new IllegalStateException("Unexpected error"));
+
+      StepVerifier.create(serviceClient.getHealthService(SERVICE_NAME, BASE_URL))
+          .expectNextCount(1)
+          .verifyComplete(); // must NOT call verifyError()
+    }
+  }
+}

--- a/ms-gateway/src/test/java/com/sportspulse/gateway/services/HealthServiceImplTest.java
+++ b/ms-gateway/src/test/java/com/sportspulse/gateway/services/HealthServiceImplTest.java
@@ -1,0 +1,208 @@
+package com.sportspulse.gateway.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.sportspulse.gateway.config.properties.GatewayServicesProperties;
+import com.sportspulse.gateway.integration.client.ServiceClient;
+import com.sportspulse.gateway.services.components.GatewayHealthIndicator;
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HealthServiceImpl Tests")
+class HealthServiceImplTest {
+
+  @Mock private ServiceClient serviceClient;
+  @Mock private GatewayServicesProperties properties;
+  @Mock private GatewayHealthIndicator gatewayHealthIndicator;
+
+  @InjectMocks private HealthServiceImpl healthService;
+
+  // -------------------------------------------------------------------------
+  // Common stubs — properties always return a URL
+  // -------------------------------------------------------------------------
+
+  @BeforeEach
+  void stubProperties() {
+    when(properties.getAuth()).thenReturn("http://ms-auth:8080");
+    when(properties.getLeagues()).thenReturn("http://ms-leagues:8080");
+    when(properties.getTeams()).thenReturn("http://ms-teams:8080");
+    when(properties.getFixtures()).thenReturn("http://ms-fixtures:8080");
+    when(properties.getStandings()).thenReturn("http://ms-standings:8080");
+    when(properties.getNotifications()).thenReturn("http://ms-notifications:8080");
+    when(properties.getDashboard()).thenReturn("http://ms-dashboard:8080");
+  }
+
+  // Convenience: stub all 7 services with the same status
+  private void stubAllServicesWith(ServiceStatus status) {
+    when(serviceClient.getHealthService(anyString(), anyString())).thenReturn(Mono.just(status));
+  }
+
+  // =========================================================================
+  // getHeathStatusServices()
+  // =========================================================================
+
+  @Nested
+  @DisplayName("gateway status")
+  class GatewayStatus {
+
+    @Test
+    @DisplayName("should set gateway field from GatewayHealthIndicator when it returns UP")
+    void shouldSetGatewayUp_whenIndicatorReturnsUp() {
+      stubAllServicesWith(ServiceStatus.UP);
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(r -> assertThat(r.getGateway()).isEqualTo(ServiceStatus.UP))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should set gateway field from GatewayHealthIndicator when it returns DOWN")
+    void shouldSetGatewayDown_whenIndicatorReturnsDown() {
+      stubAllServicesWith(ServiceStatus.UP);
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.DOWN));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(r -> assertThat(r.getGateway()).isEqualTo(ServiceStatus.DOWN))
+          .verifyComplete();
+    }
+  }
+
+  // =========================================================================
+
+  @Nested
+  @DisplayName("dependencies aggregation")
+  class DependenciesAggregation {
+
+    @Test
+    @DisplayName("should set dependencies UP when all services are UP")
+    void shouldSetDependenciesUp_whenAllServicesAreUp() {
+      stubAllServicesWith(ServiceStatus.UP);
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(r -> assertThat(r.getDependencies()).isEqualTo(ServiceStatus.UP))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should set dependencies DOWN when at least one service is DOWN")
+    void shouldSetDependenciesDown_whenAtLeastOneServiceIsDown() {
+      // 6 UP, 1 DOWN
+      when(serviceClient.getHealthService(anyString(), anyString()))
+          .thenReturn(Mono.just(ServiceStatus.UP));
+      when(serviceClient.getHealthService("ms-auth", "http://ms-auth:8080"))
+          .thenReturn(Mono.just(ServiceStatus.DOWN));
+
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(r -> assertThat(r.getDependencies()).isEqualTo(ServiceStatus.DOWN))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should set dependencies DOWN when all services are DOWN")
+    void shouldSetDependenciesDown_whenAllServicesAreDown() {
+      stubAllServicesWith(ServiceStatus.DOWN);
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(r -> assertThat(r.getDependencies()).isEqualTo(ServiceStatus.DOWN))
+          .verifyComplete();
+    }
+  }
+
+  // =========================================================================
+
+  @Nested
+  @DisplayName("services map")
+  class ServicesMap {
+
+    @Test
+    @DisplayName("should include all 7 service keys in the response map")
+    void shouldIncludeAllSevenServiceKeys() {
+      stubAllServicesWith(ServiceStatus.UP);
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(
+              r ->
+                  assertThat(r.getServices())
+                      .containsKeys(
+                          "ms-auth",
+                          "ms-leagues",
+                          "ms-teams",
+                          "ms-fixtures",
+                          "ms-standings",
+                          "ms-notifications",
+                          "ms-dashboard"))
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should reflect individual service statuses in the map")
+    void shouldReflectIndividualStatusesInMap() {
+      when(serviceClient.getHealthService(anyString(), anyString()))
+          .thenReturn(Mono.just(ServiceStatus.UP));
+      when(serviceClient.getHealthService("ms-fixtures", "http://ms-fixtures:8080"))
+          .thenReturn(Mono.just(ServiceStatus.DOWN));
+
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(
+              r -> {
+                assertThat(r.getServices()).containsEntry("ms-fixtures", ServiceStatus.DOWN);
+                assertThat(r.getServices()).containsEntry("ms-auth", ServiceStatus.UP);
+              })
+          .verifyComplete();
+    }
+  }
+
+  // =========================================================================
+
+  @Nested
+  @DisplayName("response structure")
+  class ResponseStructure {
+
+    @Test
+    @DisplayName("should emit exactly one HealthResponse and complete")
+    void shouldEmitOneResponseAndComplete() {
+      stubAllServicesWith(ServiceStatus.UP);
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .expectNextCount(1)
+          .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("should build a fully populated HealthResponse")
+    void shouldBuildFullyPopulatedResponse() {
+      stubAllServicesWith(ServiceStatus.UP);
+      when(gatewayHealthIndicator.getGatewayStatus()).thenReturn(Mono.just(ServiceStatus.UP));
+
+      StepVerifier.create(healthService.getHeathStatusServices())
+          .assertNext(
+              r -> {
+                assertThat(r.getGateway()).isNotNull();
+                assertThat(r.getDependencies()).isNotNull();
+                assertThat(r.getServices()).isNotNull().hasSize(7);
+              })
+          .verifyComplete();
+    }
+  }
+}

--- a/ms-gateway/src/test/java/com/sportspulse/gateway/services/components/GatewayHealthIndicatorTest.java
+++ b/ms-gateway/src/test/java/com/sportspulse/gateway/services/components/GatewayHealthIndicatorTest.java
@@ -1,0 +1,112 @@
+package com.sportspulse.gateway.services.components;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.sportspulse.gateway.utils.enums.ServiceStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@DisplayName("GatewayHealthIndicator Tests")
+class GatewayHealthIndicatorTest {
+
+  private GatewayHealthIndicator healthIndicator;
+
+  @BeforeEach
+  void setUp() {
+    healthIndicator = new GatewayHealthIndicator();
+  }
+
+  // -------------------------------------------------------------------------
+  // health()
+  // -------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("health() should emit Health.up()")
+  void health_shouldEmitHealthUp() {
+    StepVerifier.create(healthIndicator.health())
+        .expectNextMatches(h -> Status.UP.equals(h.getStatus()))
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("health() should complete without error")
+  void health_shouldCompleteWithoutError() {
+    StepVerifier.create(healthIndicator.health()).expectNextCount(1).verifyComplete();
+  }
+
+  // -------------------------------------------------------------------------
+  // getGatewayStatus()
+  // -------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("getGatewayStatus() should return UP when health status is UP")
+  void getGatewayStatus_shouldReturnUp_whenHealthIsUp() {
+    StepVerifier.create(healthIndicator.getGatewayStatus())
+        .expectNext(ServiceStatus.UP)
+        .verifyComplete();
+  }
+
+  @Test
+  @DisplayName("getGatewayStatus() should return DOWN when health status is DOWN")
+  void getGatewayStatus_shouldReturnDown_whenHealthIsDown() {
+    GatewayHealthIndicator spy = spy(healthIndicator);
+    doReturn(Mono.just(Health.down().build())).when(spy).health();
+
+    StepVerifier.create(spy.getGatewayStatus()).expectNext(ServiceStatus.DOWN).verifyComplete();
+  }
+
+  @Test
+  @DisplayName("getGatewayStatus() should return DOWN when health status is UNKNOWN")
+  void getGatewayStatus_shouldReturnDown_whenHealthIsUnknown() {
+    GatewayHealthIndicator spy = spy(healthIndicator);
+    doReturn(Mono.just(Health.unknown().build())).when(spy).health();
+
+    StepVerifier.create(spy.getGatewayStatus()).expectNext(ServiceStatus.DOWN).verifyComplete();
+  }
+
+  @Test
+  @DisplayName("getGatewayStatus() should return DOWN when health status is OUT_OF_SERVICE")
+  void getGatewayStatus_shouldReturnDown_whenHealthIsOutOfService() {
+    GatewayHealthIndicator spy = spy(healthIndicator);
+    doReturn(Mono.just(Health.outOfService().build())).when(spy).health();
+
+    StepVerifier.create(spy.getGatewayStatus()).expectNext(ServiceStatus.DOWN).verifyComplete();
+  }
+
+  @Test
+  @DisplayName("getGatewayStatus() should return DOWN when health() emits an error")
+  void getGatewayStatus_shouldReturnDown_whenHealthThrowsError() {
+    GatewayHealthIndicator spy = spy(healthIndicator);
+    doReturn(Mono.error(new RuntimeException("Health check failed"))).when(spy).health();
+
+    StepVerifier.create(spy.getGatewayStatus()).expectNext(ServiceStatus.DOWN).verifyComplete();
+  }
+
+  @Test
+  @DisplayName("getGatewayStatus() should delegate to health()")
+  void getGatewayStatus_shouldCallHealthOnce() {
+    GatewayHealthIndicator spy = spy(healthIndicator);
+
+    StepVerifier.create(spy.getGatewayStatus()).expectNextCount(1).verifyComplete();
+
+    verify(spy, times(1)).health();
+  }
+
+  @Test
+  @DisplayName("getGatewayStatus() status code comparison should be case-insensitive")
+  void getGatewayStatus_shouldBeCaseInsensitive_whenStatusCodeIsLowercase() {
+    GatewayHealthIndicator spy = spy(healthIndicator);
+    Health healthWithLowercaseUp = Health.status("up").build();
+    doReturn(Mono.just(healthWithLowercaseUp)).when(spy).health();
+
+    StepVerifier.create(spy.getGatewayStatus()).expectNext(ServiceStatus.UP).verifyComplete();
+  }
+}

--- a/ms-gateway/src/test/resources/application-test.properties
+++ b/ms-gateway/src/test/resources/application-test.properties
@@ -5,6 +5,7 @@ logging.level.root=INFO
 logging.level.org.springframework.cloud.gateway=DEBUG
 logging.level.com.sportspulse.gateway=DEBUG
 logging.level.io.github.resilience4j=DEBUG
+management.endpoints.web.exposure.include=health
 
 spring.data.redis.host=localhost
 spring.data.redis.port=6379

--- a/ms-leagues/pom.xml
+++ b/ms-leagues/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sportspulse</groupId>
 	<artifactId>leagues</artifactId>
-	<version>0.0.2</version>
+	<version>0.1.0</version>
 	<name/>
 	<description/>
 	<url/>
@@ -64,6 +64,10 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ms-leagues/src/main/resources/application.properties
+++ b/ms-leagues/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}
 spring.config.import=optional:file:.env[.properties]
 logging.level.org.springframework=${SPORTS_PULSE_LEVEL_LOGIN:WARN}
 logging.level.root=${SPORTS_PULSE_LEVEL_LOGIN:INFO}
+management.endpoints.web.exposure.include=health
 
 # Documentation Configuration (Swagger/OpenAPI)
 springdoc.api-docs.enabled=${SWAGGER_UI_DOCUMENTATION_ENABLED:false}

--- a/ms-notifications/pom.xml
+++ b/ms-notifications/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sportspulse</groupId>
 	<artifactId>notifications</artifactId>
-	<version>0.0.2</version>
+	<version>0.1.0</version>
 	<name/>
 	<description/>
 	<url/>
@@ -71,6 +71,10 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ms-notifications/src/main/resources/application.properties
+++ b/ms-notifications/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}
 spring.config.import=optional:file:.env[.properties]
 logging.level.org.springframework=${SPORTS_PULSE_LEVEL_LOGIN:WARN}
 logging.level.root=${SPORTS_PULSE_LEVEL_LOGIN:INFO}
+management.endpoints.web.exposure.include=health
 
 # Datasource Configuration
 spring.datasource.url=${SPORTS_PULSE_DATASOURCE_URL_NOIFICATIONS}

--- a/ms-standings/pom.xml
+++ b/ms-standings/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sportspulse</groupId>
 	<artifactId>standings</artifactId>
-	<version>0.0.2</version>
+	<version>0.1.0</version>
 	<name/>
 	<description/>
 	<url/>
@@ -64,6 +64,10 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ms-standings/src/main/resources/application.properties
+++ b/ms-standings/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}
 spring.config.import=optional:file:.env[.properties]
 logging.level.org.springframework=${SPORTS_PULSE_LEVEL_LOGIN:WARN}
 logging.level.root=${SPORTS_PULSE_LEVEL_LOGIN:INFO}
+management.endpoints.web.exposure.include=health
 
 # Documentation Configuration (Swagger/OpenAPI)
 springdoc.api-docs.enabled=${SWAGGER_UI_DOCUMENTATION_ENABLED:false}

--- a/ms-teams/pom.xml
+++ b/ms-teams/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.sportspulse</groupId>
 	<artifactId>teams</artifactId>
-	<version>0.0.2</version>
+	<version>0.1.0</version>
 	<name/>
 	<description/>
 	<url/>
@@ -64,6 +64,10 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ms-teams/src/main/resources/application.properties
+++ b/ms-teams/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}
 spring.config.import=optional:file:.env[.properties]
 logging.level.org.springframework=${SPORTS_PULSE_LEVEL_LOGIN:WARN}
 logging.level.root=${SPORTS_PULSE_LEVEL_LOGIN:INFO}
+management.endpoints.web.exposure.include=health
 
 # Documentation Configuration (Swagger/OpenAPI)
 springdoc.api-docs.enabled=${SWAGGER_UI_DOCUMENTATION_ENABLED:false}


### PR DESCRIPTION
Closes #39

### ✨ Overview

This PR introduces the **`GET /health`** endpoint, providing a centralized view of the operational status of the gateway and all downstream microservices.

It enables administrators to quickly assess system health and identify unavailable services in real time.

---

## 🩺 Health Check Endpoint (`GET /health`)

**Access:** Public (no authentication required)

This endpoint returns the status of:

* The **API Gateway**
* All configured **downstream services**
* An aggregated **dependencies status**
* A **timestamp** indicating when the check was performed

### ✅ Response — `200 OK`

The endpoint always returns a structured JSON response with:

* `gateway`: Status of the gateway (`UP` / `DOWN`)
* `dependencies`: Overall status of downstream services
* `services`: Individual service status map
* `timestamp`: Request processing time

A service is marked:

* **`UP`** → if it responds correctly
* **`DOWN`** → if it is unavailable or fails to respond

This ensures consistent observability across the system.

---

## 🎯 Acceptance Criteria Coverage

* ✅ `GET /health` returns **200 OK**
* ✅ Includes status for all services
* ✅ Each service correctly reports **UP/DOWN**
* ✅ Includes a **timestamp** field
* ✅ Endpoint is **public and unsecured**

---

## 🧪 Testing

This PR includes comprehensive test coverage:

* ✅ Unit tests for health aggregation logic
* ✅ Integration tests validating:

  * Gateway status reporting
  * Downstream service status resolution
  * Response structure and contract

---

## 📌 Notes

* The endpoint is designed to be lightweight and fast, suitable for monitoring and alerting integrations.
* It provides a consistent contract that can be used by external monitoring tools or dashboards.
